### PR TITLE
fix links and include Todd Montgomery

### DIFF
--- a/_includes/index.md
+++ b/_includes/index.md
@@ -22,10 +22,10 @@ We anticipate that acceptance of this Reactive Streams specification and experie
 
 Available immediately is a First Draft Specification covering:
 
-* [Semantics](https://github.com/reactive-streams/reactive-streams/blob/master/tck/src/main/resources/spec.md)—a specification document
-* [API](https://github.com/reactive-streams/reactive-streams/tree/master/spi/src/main/java/org/reactivestreams/api/)—Java interfaces for end users
-* [SPI](https://github.com/reactive-streams/reactive-streams/tree/master/spi/src/main/java/org/reactivestreams/spi/)—Java interfaces for implementations
-* [TCK](https://github.com/reactive-streams/reactive-streams/tree/master/tck/src/main/java/org/reactivestreams/tck/)—a test harness to validate implementations and guide implementors
+* [Semantics](https://github.com/reactive-streams/reactive-streams/blob/v0.3/tck/src/main/resources/spec.md)—a specification document
+* [API](https://github.com/reactive-streams/reactive-streams/tree/v0.3/spi/src/main/java/org/reactivestreams/api/)—Java interfaces for end users
+* [SPI](https://github.com/reactive-streams/reactive-streams/tree/v0.3/spi/src/main/java/org/reactivestreams/spi/)—Java interfaces for implementations
+* [TCK](https://github.com/reactive-streams/reactive-streams/tree/v0.3/tck/src/main/java/org/reactivestreams/tck/)—a test harness to validate implementations and guide implementors
 
 All of the parts of the Draft Proposal is released under [Creative Commons Zero](http://creativecommons.org/publicdomain/zero/1.0) (Public Domain).
 
@@ -56,4 +56,4 @@ For feedback on
 
 ## Implementors
 
-To get started implementing the draft specification, it is recommended to start by reading the [README](https://github.com/reactive-streams/reactive-streams/blob/master/README.md), then taking a look at the [Specification](https://github.com/reactive-streams/reactive-streams/blob/master/tck/src/main/resources/spec.md) then taking a look at the [TCK](https://github.com/reactive-streams/reactive-streams/tree/master/tck/src/main/java/org/reactivestreams/tck/). If you have an issue with any of the above, please take a look at [closed issues](https://github.com/reactive-streams/reactive-streams/issues?page=1&state=closed) and then open a [new issue](https://github.com/reactive-streams/reactive-streams/issues/new) if it has not already been answered.
+To get started implementing the draft specification, it is recommended to start by reading the [README](https://github.com/reactive-streams/reactive-streams/blob/v0.3/README.md), then taking a look at the [Specification](https://github.com/reactive-streams/reactive-streams/blob/v0.3/tck/src/main/resources/spec.md) then taking a look at the [TCK](https://github.com/reactive-streams/reactive-streams/tree/v0.3/tck/src/main/java/org/reactivestreams/tck/). If you have an issue with any of the above, please take a look at [closed issues](https://github.com/reactive-streams/reactive-streams/issues?page=1&state=closed) and then open a [new issue](https://github.com/reactive-streams/reactive-streams/issues/new) if it has not already been answered.

--- a/_layouts/index.html
+++ b/_layouts/index.html
@@ -30,6 +30,7 @@
               <p><span class="person">Stephane Maldini</span> &ndash; <span class="company">Pivotal Software Inc.</span></p>
               <p><span class="person">Norman Maurer</span> &ndash; <span class="company">Red Hat Inc.</span></p>
               <p><span class="person">Erik Meijer</span> &ndash; <span class="company">Applied Duality Inc.</span></p>
+              <p><span class="person">Todd Montgomery</span> &ndash; <span class="company">Kaazing Corp.</span></p>
               <p><span class="person">Patrik Nordwall</span> &ndash; <span class="company">Typesafe Inc.</span></p>
               <p><span class="person">Johannes Rudolph</span> &ndash; <span class="company">spray.io</span></p>
               <p><span class="person">Endre Varga</span> &ndash; <span class="company">Typesafe Inc.</span></p>


### PR DESCRIPTION
- point links to stable tag v0.3 instead of master (which is now out of
  sync); will point to next release when that is done
