### PR TITLE
Add link to Reactive Rabbit

### DIFF
--- a/_includes/index.md
+++ b/_includes/index.md
@@ -55,6 +55,9 @@ For feedback on
    * See [github.com/ReactiveX/RxJavaReactiveStreams](https://github.com/ReactiveX/RxJavaReactiveStreams).
 * [Ratpack](http://www.ratpack.io)
    * See the [“Streams”](http://www.ratpack.io/manual/current/streams.html) chapter of the manual.
+* Reactive Rabbit
+   * Driver for RabbitMQ/AMQP.
+   * See [github.com/ScalaConsultants/reactive-rabbit](https://github.com/ScalaConsultants/reactive-rabbit).
 
 ## Implementors
 


### PR DESCRIPTION
Reactive Rabbit is Reactive Streams driver for RabbitMQ/AMQP.
